### PR TITLE
1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Custom Copyright - de.mightful_noobs.customcopyright
 **Adds your own copyright text.**
 
 The plugin allows you to add your own copyright notice to your homepage without having to create your own templates.
-There is one option to activate the whole thing and one for the text. Only if text is included and the option is activated, it will be displayed on the pages above the Woltlab copyright.
+There is one option to activate the whole thing and one for the text. Only if text is included and the option is activated, it will be displayed on the pages above the WoltLab copyright.
 
 ## Supported Versions:
 - WoltLab Suite 3.0
@@ -13,7 +13,7 @@ There is one option to activate the whole thing and one for the text. Only if te
 - WoltLab Suite 5.4
 
 ## License Agreement:
-- Creative Commons <by-nc> (https://github.com/D1strict/de.mightful_noobs.rsi_pf/blob/master/LICENSE)
+- MIT License <by-nc> (https://github.com/felix-d1strict/de.mightful_noobs.customcopyright/blob/main/LICENSE)
 
 ## Website
 - https://mightful-noobs.de/

--- a/language/de.xml
+++ b/language/de.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <language xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/maelstrom/language.xsd" languagecode="de" languagename="Deutsch" countrycode="de">
 	<category name="wcf.acp.option">
-		<item name="wcf.acp.option.category.customcopyright.settings"><![CDATA[Benutzerdefinierter Copyright]]></item>
+		<item name="wcf.acp.option.category.customcopyright.settings"><![CDATA[Benutzerdefiniertes Copyright]]></item>
 		<item name="wcf.acp.option.customcopyright_text"><![CDATA[Copyright Text]]></item>
-		<item name="wcf.acp.option.customcopyright_html"><![CDATA[HTML aktvieren]]></item>
+		<item name="wcf.acp.option.customcopyright_html"><![CDATA[HTML-Code im Copyright verwenden]]></item>
 		<item name="wcf.acp.option.customcopyright_enable"><![CDATA[Copyright im Footer aktivieren]]></item>
 	</category>
 </language>

--- a/language/en.xml
+++ b/language/en.xml
@@ -3,7 +3,7 @@
 	<category name="wcf.acp.option">
 		<item name="wcf.acp.option.category.customcopyright.settings"><![CDATA[Custom Copyright]]></item>
 		<item name="wcf.acp.option.customcopyright_text"><![CDATA[Copyright Text]]></item>
-		<item name="wcf.acp.option.customcopyright_html"><![CDATA[Activate HTML]]></item>
+		<item name="wcf.acp.option.customcopyright_html"><![CDATA[Enable HTML code in copyright]]></item>
 		<item name="wcf.acp.option.customcopyright_enable"><![CDATA[Activate Copyright in Footer]]></item>
 	</category>
 </language>

--- a/option.xml
+++ b/option.xml
@@ -2,7 +2,6 @@
 <data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/maelstrom/option.xsd">
 	<import>
 		<categories>
-			
 			<category name="customcopyright.settings">
 				<parent>general.page</parent>
 			</category>

--- a/option.xml
+++ b/option.xml
@@ -8,20 +8,22 @@
 			</category>
 		</categories>
 		<options>
-			<option name="customcopyright_text">
-				<categoryname>customcopyright.settings</categoryname>
-				<parent>customcopyright.settings</parent>
-				<optiontype>textarea</optiontype>
-				<showorder>1</showorder>
-			</option>
-			<option name="customcopyright_html">
+			<option name="customcopyright_enable">
 				<categoryname>customcopyright.settings</categoryname>
 				<parent>customcopyright.settings</parent>
 				<optiontype>boolean</optiontype>
 				<defaultvalue>0</defaultvalue>
-				<showorder>2</showorder>
+				<showorder>1</showorder>
+				<enableoptions>customcopyright_text,customcopyright_html</enableoptions>
 			</option>
-			<option name="customcopyright_enable">
+			<option name="customcopyright_text">
+				<categoryname>customcopyright.settings</categoryname>
+				<parent>customcopyright.settings</parent>
+				<optiontype>textareaI18n</optiontype>
+				<showorder>2</showorder>
+				<supporti18n>1</supporti18n>
+			</option>
+			<option name="customcopyright_html">
 				<categoryname>customcopyright.settings</categoryname>
 				<parent>customcopyright.settings</parent>
 				<optiontype>boolean</optiontype>

--- a/package.xml
+++ b/package.xml
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package name="de.mightful_noobs.customcopyrighttext" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/vortex/package.xsd">
+<package xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/vortex/package.xsd" name="de.mightful_noobs.customcopyrighttext">
 	<packageinformation>
-		<packagename>Custom Copyright</packagename>
-		<packagename language="de">Benutzerdefinierter Copyright</packagename>
-		<packagedescription>Add your own copyright text.</packagedescription>
-		<packagedescription language="de">Fügt einen eigenen Copyright-Text hinzu.</packagedescription>
-		<version>1.2.3</version>
-		<date>2020-10-02</date>
+		<!-- de.mightful_noobs.customcopyrighttext -->
+		<packagename><![CDATA[Custom Copyright]]></packagename>
+		<packagename language="de"><![CDATA[Benutzerdefiniertes Copyright]]></packagename>
+		<packagedescription><![CDATA[Add your own copyright text.]]></packagedescription>
+		<packagedescription language="de"><![CDATA[Fügt einen eigenen Copyright-Text hinzu.]]></packagedescription>
+		<version>1.3.0</version>
+		<date>2022-03-07</date>
+		<packageurl>https://www.woltlab.com/pluginstore/file/6331-custom-copyright/</packageurl>
+		<license>https://github.com/xopez/de.mightful_noobs.customcopyright/blob/main/LICENSE</license>
 	</packageinformation>
-
 	<authorinformation>
-		<author>Xopez</author>
+		<author><![CDATA[Xopez]]></author>
 		<authorurl>https://mightful-noobs.de/</authorurl>
 	</authorinformation>
-
+	<requiredpackages>
+		<requiredpackage minversion="3.0.0 Alpha 1">com.woltlab.wcf</requiredpackage>
+	</requiredpackages>
 	<excludedpackages>
 		<excludedpackage version="6.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
 	</excludedpackages>
-
-	<requiredpackages>
-		<requiredpackage minversion="3.0.0">com.woltlab.wcf</requiredpackage>
-	</requiredpackages>
-
 	<instructions type="install">
 		<instruction type="option"/>
 		<instruction type="templateListener"/>
@@ -33,5 +32,4 @@
 		<instruction type="templateListener"/>
 		<instruction type="language"/>
 	</instructions>
-
 </package>

--- a/templateListener.xml
+++ b/templateListener.xml
@@ -5,7 +5,7 @@
 			<environment>user</environment>
 			<templatename>pageFooterCopyright</templatename>
 			<eventname>copyright</eventname>
-			<templatecode><![CDATA[{if !CUSTOMCOPYRIGHT_TEXT|empty && CUSTOMCOPYRIGHT_ENABLE}<div class="copyright">{if CUSTOMCOPYRIGHT_HTML}{@CUSTOMCOPYRIGHT_TEXT}{else}{CUSTOMCOPYRIGHT_TEXT}{/if}</div>{/if}]]></templatecode>
+			<templatecode><![CDATA[{if !CUSTOMCOPYRIGHT_TEXT|empty && CUSTOMCOPYRIGHT_ENABLE}<div class="copyright">{if CUSTOMCOPYRIGHT_HTML}{@CUSTOMCOPYRIGHT_TEXT|language}{else}{CUSTOMCOPYRIGHT_TEXT|language}{/if}</div>{/if}]]></templatecode>
 		</templatelistener>
 	</import>
 </data>


### PR DESCRIPTION
- Internationalization added;
- Options now [depend on the activation option](https://github.com/xopez/de.mightful_noobs.customcopyright/blob/eb9197c9122f39fe9caca3686fa7121230e46893/option.xml#L17). 
- Typo fixed;
- Language variable unified (similar to the language variable [wcf.acp.notice.noticeUseHtml](https://github.com/WoltLab/WCF/blob/5.4/wcfsetup/install/lang/de.xml#L1271) given by the WSC);
- License of README.md fixed;

[de.mightful_noobs.customcopyright.tar.gz](https://github.com/xopez/de.mightful_noobs.customcopyright/files/8196840/de.mightful_noobs.customcopyright.tar.gz)